### PR TITLE
fix: tweet.pyのmain関数を引数を受け取れるように修正

### DIFF
--- a/main.py
+++ b/main.py
@@ -366,16 +366,13 @@ def run_tweet(target_date: str) -> bool:
             logger.error(f"ファイル {tweet_file} が見つかりません。")
             return False
         
-        # モジュールのmain関数を直接呼び出す
-        # tweet.py は日付(YYYYMMDD)を引数として受け取る
-        sys.argv = ['tweet.py', target_date]
-        
         # ロガーのレベルを一時的に変更して詳細なログを表示
         original_level = logger.level
         logger.setLevel(logging.INFO)
         
         try:
-            tweet_main()
+            # tweet.main() を直接呼び出し、日付を引数として渡す
+            tweet_main(target_date)
             return True
         finally:
             # 元のログレベルに戻す

--- a/tweet.py
+++ b/tweet.py
@@ -248,8 +248,13 @@ def post_tweet_with_retry(client, text, in_reply_to_tweet_id=None, max_retries=3
     logger.error("ツイート投稿のリトライ上限回数に達しました。")
     return None
 
-def main():
-    """メイン処理を実行する関数"""
+def main(date=None):
+    """メイン処理を実行する関数
+    
+    Args:
+        date (str, optional): 処理対象の日付 (YYYYMMDD形式)。
+                             指定がない場合はコマンドライン引数から取得します。
+    """
     # --- Logger Setup ---
     global_logger = setup_logger(level=logging.INFO)
     # ---------------------
@@ -280,13 +285,14 @@ def main():
         global_logger.critical(f"❌ Twitter APIクライアント作成または認証チェック中にエラー: {e}", exc_info=True)
         return 1
 
-    # コマンドライン引数
-    if len(sys.argv) < 2:
-        global_logger.error("日付引数がありません。")
-        print("使用方法: python tweet.py <日付 (例: 20250129)>")
-        return 1
-
-    date = sys.argv[1]
+    # 日付の取得
+    if date is None:
+        # コマンドライン引数から日付を取得
+        if len(sys.argv) < 2:
+            global_logger.error("日付引数がありません。")
+            print("使用方法: python tweet.py <日付 (例: 20250129)>")
+            return 1
+        date = sys.argv[1]
     global_logger.info("=== tweet 処理開始 ===")
     global_logger.info(f"対象日付: {date}")
 


### PR DESCRIPTION
## 変更内容
- `tweet.py` の `main()` 関数を修正し、日付を引数として受け取れるようにしました
- コマンドライン引数からの日付取得と関数引数からの日付取得を両対応
- `main.py` から `tweet.main()` を直接呼び出すように修正
- 不要な `sys.argv` の操作を削除

## 動作確認
- [x] `python tweet.py 20250728` で通常通り動作すること
- [x] `python main.py --tweet` で複数のツイートが正しく処理されること

## 影響範囲
- `tweet.py` を直接実行する場合
- `main.py` から `--tweet` オプションを指定して実行する場合