### PR TITLE
fix: NHKスクレイパーの不要な警告ログ抑制

### DIFF
--- a/common/episode_processor.py
+++ b/common/episode_processor.py
@@ -98,7 +98,7 @@ class EpisodeProcessor:
                     self.logger.debug(f"エピソードタイトルを抽出しました: {program_title} - {episode_title}")
                     return episode_title
             except NoSuchElementException:
-                self.logger.warning(f"エピソードタイトルの取得に失敗しました: {program_title}")
+                self.logger.info(f"一覧ページからのタイトル取得をスキップ（詳細ページで取得を試みます）: {program_title}")
                 return None
 
         return None

--- a/scraping_news.py
+++ b/scraping_news.py
@@ -1061,6 +1061,7 @@ def _pad_to_width(text: str, target_width: int) -> str:
 def main():
     """メイン関数"""
     # --- Logger Setup ---
+    # --- Logger Setup ---
     global_logger = setup_logger(level=logging.INFO)
     # global_logger = setup_logger(level=logging.DEBUG)
     # ---------------------


### PR DESCRIPTION
NHKスクレイパーにおいて、一覧ページでタイトルが取得できなかった際の不要な警告を抑制し、ログのノイズを削減しました。