### PR TITLE
fix: ワーカープロセスのログ出力改善とNHKスクレイピングの安定化

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -37,7 +37,7 @@ class Constants:
         SHORT_TIMEOUT = 5 # 短めのタイムアウトを追加 (必要に応じて調整)
         PAGE_LOAD_TIMEOUT = 60  # ページ全体の読み込みタイムアウト（秒）
         TVTOKYO_ELEMENT_TIMEOUT = 10  # TV東京の要素待機タイムアウト（秒）
-        NHK_ELEMENT_TIMEOUT = 5  # NHKの要素待機タイムアウト（秒）
+        NHK_ELEMENT_TIMEOUT = 10  # NHKの要素待機タイムアウト（秒）
 
     class Program:
         """番組関連の定数"""

--- a/scraping_news.py
+++ b/scraping_news.py
@@ -107,8 +107,8 @@ class NHKScraper(BaseScraper):
         processed_episodes_count = 0
         
         for retry in range(max_scroll_retries + 1):
-            # 空番組での長期待機（ボトルネック）を避けるため、要素出現待機は5秒に短縮する
-            episodes = self.episode_processor.find_episode_elements(driver, program_title, timeout=5)
+            # 空番組での長期待機（ボトルネック）を避けるため、要素出現待機時間を定数から取得
+            episodes = self.episode_processor.find_episode_elements(driver, program_title, timeout=Constants.Time.NHK_ELEMENT_TIMEOUT)
             if not episodes:
                 if retry == 0:
                     self.logger.info(f"[{program_title}] 初回描画でエピソードリストが空です。対象エピソードなしと判断します。")
@@ -858,6 +858,9 @@ def init_worker():
         manager = WebDriverManager()
         worker_driver = manager.__enter__()
         atexit.register(cleanup_worker)
+        
+        # ロガーを初期化
+        setup_logger(level=logging.INFO)
         
         import os
         print(f" [DEBUG] ワーカープロセスを初期化しました (PID: {os.getpid()})", flush=True)


### PR DESCRIPTION
fix: ワーカープロセスのログレベル適正化とNHK取得待機時間の延長

【背景・目的】
並列スクレイピング実行時に一部の番組（ETV特集など）が「対象なし」と誤判定され、
かつその理由がコンソールに出力されない問題が発生していました。
調査の結果、以下の2点が原因であることが判明したため修正を行いました。
1. ワーカープロセスでログ設定が初期化されず、INFOレベルのログが抑制されていた。
2. NHKの要素待機時間（5秒）が、並列処理による高負荷環境では不十分であった。

【変更内容】
- scraping_news.py: init_worker 内で setup_logger を呼び出し、ワーカー側のログレベルを INFO に設定
- common/utils.py: NHK_ELEMENT_TIMEOUT を 5s から 10s に延長し、取得の安定性を向上
- scraping_news.py: NHKScraper 内のハードコードされた待機時間を定数参照に修正

【効果】
- 「対象なし」と判断した際の詳細な経緯（初回描画が空だったのか、リトライが尽きたのか等）がログで確認可能になります。
- 待機時間の延長により、通信遅延やシステム負荷による取得漏れを抑制します。
